### PR TITLE
Decrease log retention for both Kafka clusters to 12h

### DIFF
--- a/amq-streams/kafka/00-kafka-route.yaml
+++ b/amq-streams/kafka/00-kafka-route.yaml
@@ -33,7 +33,7 @@ spec:
       transaction.state.log.min.isr: 3
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"
-      log.retention.hours: 48
+      log.retention.hours: 12
       log.segment.bytes: 256000000
     storage:
       volumes:

--- a/strimzi/kraft-mode/kafka/00-kafka-route.yaml
+++ b/strimzi/kraft-mode/kafka/00-kafka-route.yaml
@@ -91,7 +91,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
-      log.retention.hours: 120
+      log.retention.hours: 12
       log.segment.bytes: 256000000
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"

--- a/strimzi/zookeeper-mode/kafka/00-kafka-route.yaml
+++ b/strimzi/zookeeper-mode/kafka/00-kafka-route.yaml
@@ -66,7 +66,7 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
-      log.retention.hours: 120
+      log.retention.hours: 12
       log.segment.bytes: 256000000
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"


### PR DESCRIPTION
This PR decreases retention policy for both clusters (i.e., ZK-based, KRaft) for the clean storages and then we would create PR new PR to set to 3 or 4 days.