### PR TITLE
[KafkaTopics] - set upper bound on size of KafkaTopics 

### DIFF
--- a/amq-streams/kafka/00-kafka-route.yaml
+++ b/amq-streams/kafka/00-kafka-route.yaml
@@ -34,7 +34,7 @@ spec:
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"
       log.retention.hours: -1 # i.e., not time limit is applied
-      retention.bytes: 107374182400 # 100 GBs (where 1 GB is equivalent to 1,073,741,824 bytes.)
+      retention.bytes: 26214400  # 200 MiB
       log.segment.bytes: 256000000
     storage:
       volumes:

--- a/amq-streams/kafka/00-kafka-route.yaml
+++ b/amq-streams/kafka/00-kafka-route.yaml
@@ -33,7 +33,8 @@ spec:
       transaction.state.log.min.isr: 3
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"
-      log.retention.hours: 48
+      log.retention.hours: -1 # i.e., not time limit is applied
+      retention.bytes: 107374182400 # 100 GBs (where 1 GB is equivalent to 1,073,741,824 bytes.)
       log.segment.bytes: 256000000
     storage:
       volumes:

--- a/strimzi/kraft-mode/kafka/00-kafka-route.yaml
+++ b/strimzi/kraft-mode/kafka/00-kafka-route.yaml
@@ -92,7 +92,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       log.retention.hours: -1 # i.e., not time limit is applied
-      retention.bytes: 107374182400 # 100 GBs (where 1 GB is equivalent to 1,073,741,824 bytes.)
+      retention.bytes: 26214400  # 200 MiB
       log.segment.bytes: 256000000
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"

--- a/strimzi/kraft-mode/kafka/00-kafka-route.yaml
+++ b/strimzi/kraft-mode/kafka/00-kafka-route.yaml
@@ -91,7 +91,8 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
-      log.retention.hours: 48
+      log.retention.hours: -1 # i.e., not time limit is applied
+      retention.bytes: 107374182400 # 100 GBs (where 1 GB is equivalent to 1,073,741,824 bytes.)
       log.segment.bytes: 256000000
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"

--- a/strimzi/zookeeper-mode/kafka/00-kafka-route.yaml
+++ b/strimzi/zookeeper-mode/kafka/00-kafka-route.yaml
@@ -67,7 +67,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       log.retention.hours: -1 # i.e., not time limit is applied
-      retention.bytes: 107374182400 # 100 GBs (where 1 GB is equivalent to 1,073,741,824 bytes.)
+      retention.bytes: 26214400  # 200 MiB (the max size for our storage currently would be 1.07 GiB per partition we have 1150 partitions for all KafkaTopics)
       log.segment.bytes: 256000000
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"

--- a/strimzi/zookeeper-mode/kafka/00-kafka-route.yaml
+++ b/strimzi/zookeeper-mode/kafka/00-kafka-route.yaml
@@ -66,7 +66,8 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
-      log.retention.hours: 48
+      log.retention.hours: -1 # i.e., not time limit is applied
+      retention.bytes: 107374182400 # 100 GBs (where 1 GB is equivalent to 1,073,741,824 bytes.)
       log.segment.bytes: 256000000
       log.message.format.version: "3.6"
       inter.broker.protocol.version: "3.6"


### PR DESCRIPTION
This PR adds an upper bound size of each partition I have calculated approximately a max size for our current `strimzi-kafka` (i.e., Anubis) cluster which is 1.07GiB for 2310GiB for PVCs we have with respect to 5 replication and 3 replication factor for each KafkaNodePool :). I have set all size partitions to 200MiB to see if all storages would be at their 25% capacity maybe a little bit more so then we could redeploy clusters with less storage overhead.  

Also, this is an initial PR to set an unlimited load to our producers because storage now will be fixed. So when we add some KafkaTopic we should be very careful :) 


```python
# Total storage capacity
total_storage_gib = 2310

# Number of partitions
total_partitions = 1150

# Replication factors for the two pools
replication_factor_pool_1 = 5
replication_factor_pool_2 = 3

# Assuming an equal distribution of partitions across the two pools
partitions_pool_1 = total_partitions / 2
partitions_pool_2 = total_partitions / 2

# Calculating usable storage for each pool
usable_storage_pool_1 = total_storage_gib / replication_factor_pool_1
usable_storage_pool_2 = total_storage_gib / replication_factor_pool_2

# Total usable storage
total_usable_storage = usable_storage_pool_1 + usable_storage_pool_2

# Storage per partition
storage_per_partition = total_usable_storage / total_partitions

# Convert GiB to bytes for retention.bytes (1 GiB = 2^30 bytes)
storage_per_partition_bytes = storage_per_partition * (2**30)

storage_per_partition_bytes = 1.07GiB
```