### PR TITLE
[Kafka clients] - Add more load to clients

### DIFF
--- a/strimzi/zookeeper-mode/clients-kustomize/overlays/big-external/producer.yaml
+++ b/strimzi/zookeeper-mode/clients-kustomize/overlays/big-external/producer.yaml
@@ -414,6 +414,6 @@ spec:
             - name: TOPIC
               value: big-external-data
             - name: DELAY_MS
-              value: "1000"
+              value: "100"
             - name: BOOTSTRAP_SERVERS
               value: anubis-kafka-automation-bootstrap-strimzi-kafka.apps.worker-01.strimzi.app-services-dev.net:443

--- a/strimzi/zookeeper-mode/clients-kustomize/overlays/big-internal/producer.yaml
+++ b/strimzi/zookeeper-mode/clients-kustomize/overlays/big-internal/producer.yaml
@@ -414,7 +414,7 @@ spec:
             - name: TOPIC
               value: big-internal-data
             - name: DELAY_MS
-              value: "1000"
+              value: "100"
             - name: USER_CRT
               value: ${secrets:strimzi-kafka/kafka-internal-producer:user.crt}
             - name: USER_KEY

--- a/strimzi/zookeeper-mode/clients-kustomize/overlays/fast-external/producer.yaml
+++ b/strimzi/zookeeper-mode/clients-kustomize/overlays/fast-external/producer.yaml
@@ -12,7 +12,7 @@ spec:
             - name: TOPIC
               value: fast-external-data
             - name: DELAY_MS
-              value: "5"  # 500 msg/s
+              value: "1"  # 1000 msg/s
             - name: USER_CRT
               value: ${secrets:strimzi-kafka/kafka-external-producer:user.crt}
             - name: USER_KEY

--- a/strimzi/zookeeper-mode/clients-kustomize/overlays/fast-internal/producer.yaml
+++ b/strimzi/zookeeper-mode/clients-kustomize/overlays/fast-internal/producer.yaml
@@ -23,7 +23,7 @@ spec:
             - name: TOPIC
               value: fast-internal-data
             - name: DELAY_MS
-              value: "5"  # 500 msg/s
+              value: "1"  # 1000 msg/s
             - name: USER_CRT
               value: ${secrets:strimzi-kafka/kafka-internal-producer:user.crt}
             - name: USER_KEY

--- a/strimzi/zookeeper-mode/clients-kustomize/overlays/iot-external/producer.yaml
+++ b/strimzi/zookeeper-mode/clients-kustomize/overlays/iot-external/producer.yaml
@@ -15,7 +15,7 @@ spec:
             - name: TOPIC
               value: iot-external-data
             - name: DELAY_MS
-              value: "1000"
+              value: "1"
             - name: USER_CRT
               value: ${secrets:strimzi-kafka/kafka-external-producer:user.crt}
             - name: USER_KEY

--- a/strimzi/zookeeper-mode/clients-kustomize/overlays/iot-internal/producer.yaml
+++ b/strimzi/zookeeper-mode/clients-kustomize/overlays/iot-internal/producer.yaml
@@ -23,7 +23,7 @@ spec:
             - name: TOPIC
               value: iot-internal-data
             - name: DELAY_MS
-              value: "1000"
+              value: "1"
             - name: USER_CRT
               value: ${secrets:strimzi-kafka/kafka-internal-producer:user.crt}
             - name: USER_KEY

--- a/strimzi/zookeeper-mode/clients/01-clients.yaml
+++ b/strimzi/zookeeper-mode/clients/01-clients.yaml
@@ -498,7 +498,7 @@ spec:
         - name: TOPIC
           value: big-external-data
         - name: DELAY_MS
-          value: "1000"
+          value: "100"
         - name: BOOTSTRAP_SERVERS
           value: anubis-kafka-automation-bootstrap-strimzi-kafka.apps.worker-01.strimzi.app-services-dev.net:443
         - name: CA_CRT
@@ -1094,7 +1094,7 @@ spec:
         - name: TOPIC
           value: big-internal-data
         - name: DELAY_MS
-          value: "1000"
+          value: "100"
         - name: USER_CRT
           value: ${secrets:strimzi-kafka/kafka-internal-producer:user.crt}
         - name: USER_KEY
@@ -1292,7 +1292,7 @@ spec:
         - name: TOPIC
           value: fast-external-data
         - name: DELAY_MS
-          value: "5"
+          value: "1"
         - name: USER_CRT
           value: ${secrets:strimzi-kafka/kafka-external-producer:user.crt}
         - name: USER_KEY
@@ -1501,7 +1501,7 @@ spec:
         - name: TOPIC
           value: fast-internal-data
         - name: DELAY_MS
-          value: "5"
+          value: "1"
         - name: USER_CRT
           value: ${secrets:strimzi-kafka/kafka-internal-producer:user.crt}
         - name: USER_KEY
@@ -1702,7 +1702,7 @@ spec:
         - name: TOPIC
           value: iot-external-data
         - name: DELAY_MS
-          value: "1000"
+          value: "1"
         - name: USER_CRT
           value: ${secrets:strimzi-kafka/kafka-external-producer:user.crt}
         - name: USER_KEY
@@ -1911,7 +1911,7 @@ spec:
         - name: TOPIC
           value: iot-internal-data
         - name: DELAY_MS
-          value: "1000"
+          value: "1"
         - name: USER_CRT
           value: ${secrets:strimzi-kafka/kafka-internal-producer:user.crt}
         - name: USER_KEY


### PR DESCRIPTION
After we change from time-based to size-based retention we could add more load now and we are not limited by the storage size but only HW which we have. This PR adds a little more load to current clients.