### PR TITLE
[KafkaBridge] - invalid json fix

### DIFF
--- a/metrics/grafana/dashboards/00-kafka-bridge-dashboard.yaml
+++ b/metrics/grafana/dashboards/00-kafka-bridge-dashboard.yaml
@@ -3423,7 +3423,7 @@ spec:
             "tagsQuery": "",
             "type": "query",
             "useTags": false
-          },
+          }
         ]
       },
       "time": {


### PR DESCRIPTION
There was a problem for the Grafana controller loading current Bridge dashboard because of the problem:
```java
2024-02-19T12:43:47Z	ERROR	GrafanaDashboardReconciler	failed to prepare dashboard model	{"controller": "grafanadashboard", "controllerGroup": "grafana.integreatly.org", "controllerKind": "GrafanaDashboard", "GrafanaDashboard": {"name":"strimzi-kafka-bridge","namespace":"tealc-monitoring"}, "namespace": "tealc-monitoring", "name": "strimzi-kafka-bridge", "reconcileID": "4c0c3375-9e61-4dd3-8825-60ce140b765b", "dashboard": "strimzi-kafka-bridge", "error": "invalid character ']' looking for beginning of value"}
```
This should resolve it. I already applied such a fix to our infra and it works
<img width="1723" alt="image" src="https://github.com/skodjob/deployment-hub/assets/30839163/a33e4928-8949-4e9b-b994-498bd16504b5">
